### PR TITLE
Update example READMEs to mention required Wallaroo versions

### DIFF
--- a/ddos-detection/README.md
+++ b/ddos-detection/README.md
@@ -8,8 +8,9 @@ Once a server is identified as under a DoS or DDoS attack, it reports to the agg
 
 ## Requirements
 
+- [Wallaroo 0.2.2](https://github.com/WallarooLabs/wallaroo/tree/0.2.2)
+	**NOTE:** This is incompatible with Wallaroo 0.4.0 and up due to an API change, see [How to Update your Wallaroo Python Applications to the new API](https://blog.wallaroolabs.com/2018/01/how-to-update-your-wallaroo-python-applications-to-the-new-api/) to bring this example up to date if needed.
 - Python 2.7.x
-- Wallaroo
 
 ## Generating Data
 

--- a/non-native-event-windowing/README.md
+++ b/non-native-event-windowing/README.md
@@ -4,6 +4,12 @@ This is an example of a stateful application that counts the occurrences of retu
 
 You will need a working [Wallaroo Python API](/book/python/intro.md).
 
+## Requirements
+
+- [Wallaroo 0.2.2](https://github.com/WallarooLabs/wallaroo/tree/0.2.2)
+	**NOTE:** This is incompatible with Wallaroo 0.4.0 and up due to an API change, see [How to Update your Wallaroo Python Applications to the new API](https://blog.wallaroolabs.com/2018/01/how-to-update-your-wallaroo-python-applications-to-the-new-api/) to bring this example up to date if needed.
+- Python 2.7.x
+
 ## Running Log Files
 
 In a shell, start up the Metrics UI if you don't already have it running:

--- a/sklearn-example/README.md
+++ b/sklearn-example/README.md
@@ -4,6 +4,15 @@ This is an example of an application that classifies streams of hand-written dig
 
 You will need a working [Wallaroo Python API](https://docs.wallaroolabs.com/book/python/intro.html).
 
+## Requirements
+
+- [Wallaroo 0.4.0](https://github.com/WallarooLabs/wallaroo/tree/0.4.0) or greater.
+- Python 2.7.x
+- Python Modules:
+  - NumPy
+  - SciPy
+  - sklearn
+
 ## Training the models
 
 Before running the application we will have to run a script to train the the scikit-learn models and serialize them for later use:

--- a/twitter-trending-hashtags/README.md
+++ b/twitter-trending-hashtags/README.md
@@ -6,13 +6,13 @@ The Twitter Trending Hashtags application receives a stream of tweets via the Tw
 
 ## Requirements
 
-- Wallaroo 0.3.3
+- [Wallaroo 0.2.2](https://github.com/WallarooLabs/wallaroo/tree/0.2.2)
+	**NOTE:** This is incompatible with Wallaroo 0.4.0 and up due to an API change, see [How to Update your Wallaroo Python Applications to the new API](https://blog.wallaroolabs.com/2018/01/how-to-update-your-wallaroo-python-applications-to-the-new-api/) to bring this example up to date if needed.
 - Python 2.7.x
 - Python Modules:
   - flask
   - requests_oauthlib
   - pandas
-- Wallaroo
 
 ## Running Instructions
 


### PR DESCRIPTION
Explicitly notifies users that 0.2.2 examples are incompatible
with Wallaroo 0.4.x due to the Python API change and points them
to the blog post for updating if they need to do so.